### PR TITLE
install.sh added

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,29 @@
+#!/bin/zsh
+
+#Exits on error
+set -e
+
+#Output Every command
+#set -x
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+if [ ! -d ~/.config/sublime-text-3/ ]; then
+  mkdir ~/.config/sublime-text-3/
+fi
+
+if [ ! -d ~/.config/sublime-text-3/Packages/ ]; then
+  mkdir ~/.config/sublime-text-3/Packages/
+fi
+
+if [ ! -d ~/.config/sublime-text-3/Packages/User ]; then
+  mkdir ~/.config/sublime-text-3/Packages/User/
+fi
+
+echo -e "Installing Files"
+
+cp -r $(pwd)/Buggy---Linux ~/.config/sublime-text-3/Packages/User/
+cp -r $(pwd)/CF ~/.config/sublime-text-3/Packages/User/


### PR DESCRIPTION
Just run `sudo ./install.sh` to copy files. No need to go to `/home/username/.config/..`
`zsh must be installed`. Also I think you must add to [`BuggyWindows`](https://github.com/pakhandi/Buggy---Windows) too!
